### PR TITLE
Link CodecFlac with libm.

### DIFF
--- a/wscript
+++ b/wscript
@@ -447,6 +447,7 @@ def build(bld):
                 'thirdparty/flac-1.2.1/src/libFLAC/ogg_mapping.c',
             ],
             use=['FLAC', 'OGG', 'libOgg', 'OHNET'],
+            shlib=['m'],
             target='CodecFlac')
 
     # AlacBase


### PR DESCRIPTION
CodecFlac uses `log` which may need `libm` to be explicitely linked on some platforms.