### PR TITLE
Correct airplay volume attenuation implementation

### DIFF
--- a/OpenHome/Media/Pipeline/Msg.cpp
+++ b/OpenHome/Media/Pipeline/Msg.cpp
@@ -2219,12 +2219,18 @@ Brn MsgPlayablePcm::ApplyAttenuation(Brn aData)
         switch (iBitDepth) {
         case 16:
             {
-                TInt16* source = (TInt16*)aData.Ptr();
-                TInt16* dest = (TInt16*)attenuatedData.Ptr();
-                TUint samples = aData.Bytes()/2;
+                TByte *source = (TByte *)aData.Ptr();
+                TByte *dest = (TByte *)attenuatedData.Ptr();
+                TUint samples = aData.Bytes()/2;  // Number of 16-bit samples
                 attenuatedData.SetBytes(aData.Bytes());
                 for(TUint i = 0; i < samples; i++) {
-                    dest[i] = (TInt16)((TInt32)source[i] * iAttenuation / MsgAudioPcm::kUnityAttenuation);
+                    TInt16 sample;
+                    TUint byteIndex = i*2;
+                    sample = source[byteIndex] << 8;
+                    sample += source[byteIndex+1];
+                    TInt attenuatedSample = sample * iAttenuation / MsgAudioPcm::kUnityAttenuation;
+                    dest[byteIndex] = attenuatedSample >> 8;
+                    dest[byteIndex+1] = (TByte)attenuatedSample;
                 }
             }
             break;


### PR DESCRIPTION
Problem Solved (first): If airplay volume is less than 100% then the player outputs noise on Intel and Arm platforms (Little endian). If airplay volume is 100% then the player outputs music. It is likely that this problem does not exist on big-endian machines.

Selected Approach:
The calculation of the airplay attenuation (in case of volume less than 100%) is performed in the same way as the existing calculation of rampup attenuation  (see Msg.cpp). This fixes the problem for Intel and ARM. It has not been tested on big endian machines. It has not been optimized for big endian machines.

Problem Solved (second): The Brn() object returned by ApplyAttenuation() when airplay volume is less then 100% is using strlen() to calculate the length of the data in the audio frame. This is a potential problem if the data includes a byte with value zero as strlen() will then return a length that is shorter than the actual audio frame resulting in potential reduction of sound quality due to possiblility of dropped audio data.

Selected Approach: The length of the audio frame is known and could be used to create an new Brn() object without using strlen() correcting the problem and improving the performance, but the selected approach is instead to avoid using the attenuationData buffer to minimize amount of data in the cache as the source data buffer is used for both source and destination, resulting in a potential performance improvement in addition to avoiding call to strlen(). A side effect is that usage of the static non-thread-safe attenuatedData buffer can be avoided.